### PR TITLE
Add .gitattributes for cross-platform line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+# This tells Git to automatically normalize line endings:
+# files will be checked out with native line endings (CRLF on Windows, LF on macOS/Linux)
+#  but always committed with LF, ensuring cross-platform consistency.


### PR DESCRIPTION
I had a warning error that the line endings were mac and windows so found a solution online. I added a .gitattributes file into our root repository and added a bit of code that should automatically convert line endings, so there won't be any issues with us all using different operating systems. 